### PR TITLE
feat: 在画板上方增加自定义提示词输入框

### DIFF
--- a/src/lib/ai-service.ts
+++ b/src/lib/ai-service.ts
@@ -30,6 +30,7 @@ export class AIServiceError extends Error {
 export async function generateFromSketch(
 	sketchDataUrl: string,
 	style: StylePreset,
+	userPrompt?: string,
 	signal?: AbortSignal
 ): Promise<GenerationResult> {
 	let generatedImageUrl: string
@@ -37,6 +38,7 @@ export async function generateFromSketch(
 		generatedImageUrl = await generateImageFromSketch(
 			sketchDataUrl,
 			style.prompt,
+			userPrompt,
 			signal
 		)
 	} catch (error) {
@@ -55,7 +57,7 @@ export async function generateFromSketch(
 		id: `gen_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
 		sketchDataUrl,
 		generatedImageUrl,
-		prompt: style.prompt,
+		prompt: userPrompt ? `${userPrompt} (风格: ${style.nameZh})` : style.prompt,
 		style,
 		createdAt: new Date(),
 	}

--- a/src/lib/openrouter.ts
+++ b/src/lib/openrouter.ts
@@ -188,13 +188,19 @@ const isRetryableError = (error: unknown): boolean => {
 export async function generateImageFromSketch(
 	sketchBase64: string,
 	stylePrompt: string,
+	userPrompt?: string,
 	signal?: AbortSignal
 ): Promise<string> {
 	const apiKey = getApiKey()
 	const model = getImageModel()
 
 	// 构建完整的 prompt
-	const fullPrompt = `Transform this sketch into: ${stylePrompt}, high quality, detailed, professional`
+	// 如果用户提供了自定义提示词，则将其与风格提示词结合
+	const combinedPrompt = userPrompt
+		? `${userPrompt}. Style: ${stylePrompt}`
+		: stylePrompt
+
+	const fullPrompt = `Transform this sketch into: ${combinedPrompt}, high quality, detailed, professional`
 
 	// 构建多模态消息，包含草图图像和文本提示
 	const messages: ChatMessage[] = [

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,6 +7,7 @@ import StyleSelector from '@/components/canvas/StyleSelector'
 import GenerationResultView from '@/components/canvas/GenerationResultView'
 import LimitExceededDialog from '@/components/canvas/LimitExceededDialog'
 import HistoryPanel from '@/components/canvas/HistoryPanel'
+import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import {
 	STYLE_PRESETS,
@@ -32,6 +33,7 @@ const Index = () => {
 	)
 	const [status, setStatus] = useState<GenerationStatus>('idle')
 	const [result, setResult] = useState<GenerationResult | null>(null)
+	const [userPrompt, setUserPrompt] = useState('')
 	const [showLimitDialog, setShowLimitDialog] = useState(false)
 	const [showHistory, setShowHistory] = useState(false)
 
@@ -78,6 +80,7 @@ const Index = () => {
 				const aiResult = await generateFromSketch(
 					sketchDataUrl,
 					selectedStyle,
+					userPrompt,
 					signal
 				)
 
@@ -123,7 +126,14 @@ const Index = () => {
 				abortControllerRef.current = null
 			}
 		},
-		[selectedStyle, toast, isLimitReached, consumeGeneration, addToHistory]
+		[
+			selectedStyle,
+			userPrompt,
+			toast,
+			isLimitReached,
+			consumeGeneration,
+			addToHistory,
+		]
 	)
 
 	const handleCloseResult = useCallback(() => {
@@ -186,7 +196,7 @@ const Index = () => {
 								transition={{ delay: 0.3 }}
 								className="flex items-center justify-end md:justify-between"
 							>
-								<div className="hidden md:flex items-center gap-2 text-sm text-muted-foreground">
+								<div className="hidden md:flex items-center gap-2 text-sm text-muted-foreground flex-1">
 									<span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
 									在画板上自由绘制您的想法
 								</div>
@@ -241,6 +251,46 @@ const Index = () => {
 											</span>
 										)}
 									</Button>
+								</div>
+							</motion.div>
+
+							{/* Prompt Input Box */}
+							<motion.div
+								initial={{ opacity: 0, y: 10 }}
+								animate={{ opacity: 1, y: 0 }}
+								transition={{ delay: 0.35 }}
+								className="relative group"
+							>
+								<div className="absolute -inset-0.5 bg-gradient-to-r from-primary/20 to-purple-500/20 rounded-xl blur opacity-0 group-focus-within:opacity-100 transition duration-500" />
+								<div className="relative">
+									<Input
+										placeholder="输入提示词描述你的草图（例如：一艘在星际穿梭的飞船）..."
+										value={userPrompt}
+										onChange={(e) => setUserPrompt(e.target.value)}
+										className="w-full bg-card/50 border-border/60 hover:border-primary/30 focus-visible:ring-primary/30 backdrop-blur-sm pr-10"
+									/>
+									{userPrompt && (
+										<button
+											onClick={() => setUserPrompt('')}
+											className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+											aria-label="清空提示词"
+										>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												width="16"
+												height="16"
+												viewBox="0 0 24 24"
+												fill="none"
+												stroke="currentColor"
+												strokeWidth="2"
+												strokeLinecap="round"
+												strokeLinejoin="round"
+											>
+												<line x1="18" y1="6" x2="6" y2="18"></line>
+												<line x1="6" y1="6" x2="18" y2="18"></line>
+											</svg>
+										</button>
+									)}
 								</div>
 							</motion.div>
 


### PR DESCRIPTION
## 变更详情
本 PR 在画板上方增加了用户自定义提示词输入框，允许用户通过文字描述辅助 AI 生成图片。

## 主要修改
1. **交互层 (UI/UX)**
    - 在 `src/pages/Index.tsx` 中新增 `Input` 组件，位于画板上方。
    - 实现了渐变模糊背景和焦点动效，保持与整体设计风格一致。
    - 添加了一键清空按钮。
    - 适配移动端布局。
2. **逻辑层 (Service)**
    - 修改 `src/lib/openrouter.ts` 和 `src/lib/ai-service.ts`，支持传递 `userPrompt`。
    - 提示词构建逻辑：`${userPrompt}. Style: ${stylePrompt}`。

## 相关 Issue
Closes #8

## 测试验证
- [x] 桌面端显示和输入正常
- [x] 移动端显示正常
- [x] 生成图片时 API 请求包含自定义提示词
- [x] 历史记录正确保存了组合后的提示词