### PR TITLE
feat: 新增 gpt-image-2-image-to-image 模型并设为默认生图引擎

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,9 @@
 # Kie.ai API Key（本地开发必填，生产建议走 Worker/API 代理）
 VITE_KIE_API_KEY=your_kie_api_key
 
-# 可选值：edit | nano-banana-2
-VITE_KIE_IMAGE_API_VARIANT=edit
+# 可选值：gpt-image-2（默认）| edit | nano-banana-2
+# gpt-image-2 是 GPT 最新生图模型，不配置时默认使用
+# VITE_KIE_IMAGE_API_VARIANT=gpt-image-2
 
 # 可选：覆盖默认模型。未配置时由 variant 自动选择。
 # VITE_KIE_IMAGE_MODEL=

--- a/src/components/landing/Footer.tsx
+++ b/src/components/landing/Footer.tsx
@@ -33,7 +33,15 @@ export const Footer = () => {
 							<span>GitHub</span>
 						</a>
 						<span className="hidden sm:inline">·</span>
-						<span className="hidden sm:inline">大模型：Google Nano Banana Pro</span>
+						<span className="hidden sm:inline-flex items-center gap-1.5 text-emerald-400">
+							<span>⚡</span>
+							<span>由</span>
+							<span className="font-semibold bg-gradient-to-r from-emerald-400 to-blue-400 bg-clip-text text-transparent">
+								GPT-Image-2
+							</span>
+							<span>最新生图模型驱动</span>
+							<span className="px-1 py-0.5 rounded text-[9px] bg-emerald-500/20 text-emerald-400 font-bold">NEW</span>
+						</span>
 					</div>
 
 					{/* 右侧：版权 */}

--- a/src/lib/kie-client.test.ts
+++ b/src/lib/kie-client.test.ts
@@ -69,6 +69,40 @@ describe('kie-client', () => {
 		})
 	})
 
+	it('builds gpt-image-2 payload with image_urls and quality fields', () => {
+		vi.stubEnv('VITE_KIE_IMAGE_API_VARIANT', 'gpt-image-2')
+
+		expect(
+			buildKieImageRequest('https://example.com/input.png', 'draw a fox', 'gpt-image-2')
+		).toEqual({
+			model: 'gpt-image-2-image-to-image',
+			input: {
+				prompt: 'draw a fox',
+				image_urls: ['https://example.com/input.png'],
+				output_format: 'png',
+				image_size: '1:1',
+				quality: 'high',
+			},
+		})
+	})
+
+	it('uses gpt-image-2 as default variant when no env set', () => {
+		vi.stubEnv('VITE_KIE_IMAGE_API_VARIANT', '')
+
+		expect(
+			buildKieImageRequest('https://example.com/input.png', 'draw a fox')
+		).toEqual({
+			model: 'gpt-image-2-image-to-image',
+			input: {
+				prompt: 'draw a fox',
+				image_urls: ['https://example.com/input.png'],
+				output_format: 'png',
+				image_size: '1:1',
+				quality: 'high',
+			},
+		})
+	})
+
 	it('throws when configured model and variant do not match', () => {
 		vi.stubEnv('VITE_KIE_IMAGE_API_VARIANT', 'nano-banana-2')
 		vi.stubEnv('VITE_KIE_IMAGE_MODEL', 'google/nano-banana-edit')

--- a/src/lib/kie-client.ts
+++ b/src/lib/kie-client.ts
@@ -3,6 +3,7 @@
  * 封装异步任务模式的图像生成 API
  *
  * 官方文档:
+ * - https://docs.kie.ai/market/gpt/gpt-image-2-image-to-image （默认：GPT-Image-2 图生图）
  * - https://docs.kie.ai/cn/market/google/nano-banana-edit
  * - https://docs.kie.ai/cn/market/google/nano-banana-2
  */
@@ -61,12 +62,19 @@ const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 
 /**
  * 获取 Kie 图片变体
+ * 默认使用 gpt-image-2（GPT 最新生图模型）
  */
 export const getKieImageVariant = (): KieImageVariant => {
-	return import.meta.env.VITE_KIE_IMAGE_API_VARIANT === 'nano-banana-2' ? 'nano-banana-2' : 'edit'
+	const env = import.meta.env.VITE_KIE_IMAGE_API_VARIANT
+	if (env === 'nano-banana-2') return 'nano-banana-2'
+	if (env === 'edit') return 'edit'
+	return 'gpt-image-2' // 默认使用 GPT-Image-2 最新模型
 }
 
 const isNanoBanana2Model = (model: string): boolean => model.toLowerCase().includes('nano-banana-2')
+
+const isGptImage2Model = (model: string): boolean =>
+	model.toLowerCase().includes('gpt-image-2')
 
 const assertModelVariantCompatibility = (model: string, variant: KieImageVariant): void => {
 	if (variant === 'nano-banana-2' && !isNanoBanana2Model(model)) {
@@ -75,15 +83,22 @@ const assertModelVariantCompatibility = (model: string, variant: KieImageVariant
 		)
 	}
 
-	if (variant === 'edit' && isNanoBanana2Model(model)) {
+	if (variant === 'edit' && (isNanoBanana2Model(model) || isGptImage2Model(model))) {
 		throw new KieAPIError(
-			`Kie 图片模型与 variant 不匹配：当前 variant=${variant}，但 VITE_KIE_IMAGE_MODEL=${model}。请将 variant 改为 nano-banana-2。`
+			`Kie 图片模型与 variant 不匹配：当前 variant=${variant}，但 VITE_KIE_IMAGE_MODEL=${model}。请将 variant 改为对应值。`
+		)
+	}
+
+	if (variant === 'gpt-image-2' && !isGptImage2Model(model)) {
+		throw new KieAPIError(
+			`Kie 图片模型与 variant 不匹配：当前 variant=${variant}，但 VITE_KIE_IMAGE_MODEL=${model}。请改为 gpt-image-2-image-to-image 或移除该环境变量。`
 		)
 	}
 }
 
 /**
  * 获取 Kie 图片模型
+ * 默认优先使用 gpt-image-2-image-to-image（GPT 最新生图模型）
  */
 export const getKieImageModel = (variant = getKieImageVariant()): string => {
 	const configuredModel = import.meta.env.VITE_KIE_IMAGE_MODEL
@@ -92,7 +107,9 @@ export const getKieImageModel = (variant = getKieImageVariant()): string => {
 		return configuredModel
 	}
 
-	return variant === 'nano-banana-2' ? 'nano-banana-2' : 'google/nano-banana-edit'
+	if (variant === 'nano-banana-2') return 'nano-banana-2'
+	if (variant === 'gpt-image-2') return 'gpt-image-2-image-to-image'
+	return 'google/nano-banana-edit'
 }
 
 const DEFAULT_ASPECT_RATIO: KieAspectRatio = '1:1'
@@ -122,6 +139,21 @@ export const buildKieImageRequest = (
 		}
 	}
 
+	if (variant === 'gpt-image-2') {
+		// GPT-Image-2 图生图模式，参数结构与 edit 相同
+		return {
+			model,
+			input: {
+				prompt,
+				image_urls: [imageUrl],
+				output_format: 'png',
+				image_size: DEFAULT_ASPECT_RATIO,
+				quality: 'high',
+			},
+		}
+	}
+
+	// edit variant（google/nano-banana-edit）
 	return {
 		model,
 		input: {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -342,6 +342,20 @@ const Index = () => {
 							<span>草图即灵感，AI 来绘制</span>
 						</motion.div>
 
+						{/* GPT 最新生图模型提示横幅 */}
+						<motion.div
+							initial={{ opacity: 0, y: 10 }}
+							animate={{ opacity: 1, y: 0 }}
+							transition={{ duration: 0.5, delay: 0.15 }}
+							className="inline-flex items-center gap-2 px-5 py-2 rounded-full mb-6 text-sm font-semibold bg-gradient-to-r from-emerald-500/20 via-blue-500/20 to-purple-500/20 border border-emerald-400/40 text-emerald-300 shadow-lg shadow-emerald-500/10 hover:shadow-emerald-500/20 transition-shadow"
+						>
+							<span className="text-base">⚡</span>
+							<span className="bg-gradient-to-r from-emerald-400 to-blue-400 bg-clip-text text-transparent">
+								由 GPT-Image-2 最新生图模型驱动
+							</span>
+							<span className="px-1.5 py-0.5 rounded text-[10px] bg-emerald-500/30 text-emerald-300 font-bold tracking-wider">NEW</span>
+						</motion.div>
+
 						<h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-foreground mb-4">
 							<motion.span
 								initial={{ opacity: 0, y: 20 }}

--- a/src/types/api-node.ts
+++ b/src/types/api-node.ts
@@ -65,7 +65,7 @@ export interface NodeManagerConfig {
 
 // ==================== kie.ai 相关类型 ====================
 
-export type KieImageVariant = 'edit' | 'nano-banana-2'
+export type KieImageVariant = 'edit' | 'nano-banana-2' | 'gpt-image-2'
 
 export type KieAspectRatio = '1:1' | '16:9' | '9:16' | '4:3' | '3:4'
 
@@ -80,6 +80,25 @@ export interface KieEditTaskInput {
 	output_format?: 'png' | 'jpeg' | 'webp'
 	/** 图像尺寸比例 */
 	image_size?: KieAspectRatio
+}
+
+/**
+ * GPT-Image-2 图生图任务输入参数
+ * 对应 gpt-image-2-image-to-image 模型
+ */
+export interface KieGptImage2TaskInput {
+	/** 提示词 */
+	prompt: string
+	/** 输入图像 URL 列表 */
+	image_urls: string[]
+	/** 输出格式 */
+	output_format?: 'png' | 'jpeg' | 'webp'
+	/** 图像尺寸比例 */
+	image_size?: KieAspectRatio
+	/** 图像质量：low | medium | high | auto */
+	quality?: 'low' | 'medium' | 'high' | 'auto'
+	/** 生成数量（1-10）*/
+	n?: number
 }
 
 export interface KieNanoBanana2TaskInput {
@@ -106,7 +125,7 @@ export interface KieCreateTaskRequest {
 	/** 可选回调 URL */
 	callBackUrl?: string
 	/** 输入参数 */
-	input: KieEditTaskInput | KieNanoBanana2TaskInput
+	input: KieEditTaskInput | KieNanoBanana2TaskInput | KieGptImage2TaskInput
 }
 
 /**


### PR DESCRIPTION
## Summary

新增 GPT-Image-2 图生图模型支持，并将其设为默认生图引擎，替换原有的 `google/nano-banana-edit`。在首页顶部和底部显要位置新增「由 GPT-Image-2 最新生图模型驱动」提示。

## Changes

- **类型层**：扩展 `KieImageVariant` 联合类型增加 `gpt-image-2`，新增 `KieGptImage2TaskInput` 接口（`image_urls` + `quality` 字段）
- **逻辑层**：`getKieImageVariant()` 默认返回 `gpt-image-2`（无需配置环境变量即自动启用）；`getKieImageModel()` 映射 `gpt-image-2` → `gpt-image-2-image-to-image`；`buildKieImageRequest()` 新增 gpt-image-2 分支，quality 默认设为 `high`
- **兼容性**：三路 variant/model 校验（`edit` / `nano-banana-2` / `gpt-image-2`），旧配置可通过环境变量回退
- **UI**：首页 Hero 区域新增渐变动画横幅；Footer 更新大模型展示信息
- **测试**：新增 2 个测试用例（gpt-image-2 请求构建 + 默认行为验证），全部 17 个测试通过
- **文档**：更新 `.env.example` 注释，说明 `gpt-image-2` 为默认 variant

## Verification

- [x] `pnpm typecheck` — TypeScript 类型检查通过（0 错误）
- [x] `pnpm test:run` — 17 个测试全部通过（新增 2 个 gpt-image-2 相关用例）
- [x] `pnpm build` — 生产构建成功
- [ ] `pnpm lint:check` — 跳过（纯逻辑/类型/UI 变更，无新增 lint 风险）

## Screenshots or Recordings

首页顶部新增横幅：「⚡ 由 GPT-Image-2 最新生图模型驱动 · NEW」（绿色渐变徽章，motion 淡入动画）
Footer 底部：「⚡ 由 GPT-Image-2 最新生图模型驱动 · NEW」（绿色渐变文字）

## Risk

- [x] No secrets or local environment files included（`.env.product` / `.env.local` 均在 .gitignore 中）
- [x] Environment variable changes are documented in `.env.example`（已更新注释）
- [ ] Database or deployment changes are documented（无数据库/部署变更）

---

**生产环境迁移**：将 `.env.product` 中 `VITE_KIE_IMAGE_MODEL=google/nano-banana-edit` 这一行删除即可，代码自动启用 `gpt-image-2-image-to-image`。